### PR TITLE
width modifiers with min/max

### DIFF
--- a/dist/muscles.css
+++ b/dist/muscles.css
@@ -464,6 +464,122 @@
   flex-basis: calc(100% * 2 / 2 - 12px);
 }
 
+/* width .flexi--wNx */
+.flexi--w1x {
+  width: calc(96px * 1);
+}
+.flexi--w2x {
+  width: calc(96px * 2);
+}
+.flexi--w3x {
+  width: calc(96px * 3);
+}
+.flexi--w4x {
+  width: calc(96px * 4);
+}
+.flexi--w5x {
+  width: calc(96px * 5);
+}
+.flexi--w6x {
+  width: calc(96px * 6);
+}
+.flexi--w7x {
+  width: calc(96px * 7);
+}
+.flexi--w8x {
+  width: calc(96px * 8);
+}
+.flexi--w9x {
+  width: calc(96px * 9);
+}
+.flexi--w10x {
+  width: calc(96px * 10);
+}
+.flexi--w11x {
+  width: calc(96px * 11);
+}
+.flexi--w12x {
+  width: calc(96px * 12);
+}
+
+/* max-width .flexi--w<Nx (width is less than Nx) */
+.flexi--w\<1x {
+  max-width: calc(96px * 1);
+}
+.flexi--w\<2x {
+  max-width: calc(96px * 2);
+}
+.flexi--w\<3x {
+  max-width: calc(96px * 3);
+}
+.flexi--w\<4x {
+  max-width: calc(96px * 4);
+}
+.flexi--w\<5x {
+  max-width: calc(96px * 5);
+}
+.flexi--w\<6x {
+  max-width: calc(96px * 6);
+}
+.flexi--w\<7x {
+  max-width: calc(96px * 7);
+}
+.flexi--w\<8x {
+  max-width: calc(96px * 8);
+}
+.flexi--w\<9x {
+  max-width: calc(96px * 9);
+}
+.flexi--w\<10x {
+  max-width: calc(96px * 10);
+}
+.flexi--w\<11x {
+  max-width: calc(96px * 11);
+}
+.flexi--w\<12x {
+  max-width: calc(96px * 12);
+}
+
+/* min-width .flexi--w>Nx (width is greater than Nx) */
+.flexi--w\>1x {
+  min-width: calc(96px * 1);
+}
+.flexi--w\>2x {
+  min-width: calc(96px * 2);
+}
+.flexi--w\>3x {
+  min-width: calc(96px * 3);
+}
+.flexi--w\>4x {
+  min-width: calc(96px * 4);
+}
+.flexi--w\>5x {
+  min-width: calc(96px * 5);
+}
+.flexi--w\>6x {
+  min-width: calc(96px * 6);
+}
+.flexi--w\>7x {
+  min-width: calc(96px * 7);
+}
+.flexi--w\>8x {
+  min-width: calc(96px * 8);
+}
+.flexi--w\>9x {
+  min-width: calc(96px * 9);
+}
+.flexi--w\>10x {
+  min-width: calc(96px * 10);
+}
+.flexi--w\>11x {
+  min-width: calc(96px * 11);
+}
+.flexi--w\>12x {
+  min-width: calc(96px * 12);
+}
+
+
+
 /**
  * order modifiers
  */

--- a/example/index.html
+++ b/example/index.html
@@ -30,6 +30,7 @@
       <div class="box flexi--b12x">12x96px</div>
     </div>
 
+
     <h2>Flex basis width percentages</h2>
     <p>.flexi--b1/12 = 1/12</p>
 
@@ -61,6 +62,33 @@
       <div class="box flexi--b3/3">3/3</div>
       <div class="box flexi--b1/2">1/2</div>
       <div class="box flexi--b2/2">2/2</div>
+    </div>
+
+    <h2>Element widths</h2>
+    <p>.flexi--w4x = width: 4*96px;</p>
+    <div class="flexb flexb--wrap container">
+      <div class="box flexi--w1x">1x</div>
+      <div class="box flexi--w2x">2x</div>
+      <div class="box flexi--w3x">3x</div>
+      <div class="box flexi--w4x">4x</div>
+      <div class="box flexi--w5x">5x</div>
+      <div class="box flexi--w6x">6x</div>
+      <div class="box flexi--w7x">7x</div>
+      <div class="box flexi--w8x">8x</div>
+      <div class="box flexi--w9x">9x</div>
+      <div class="box flexi--w10x">10x</div>
+      <div class="box flexi--w11x">11x</div>
+      <div class="box flexi--w12x">12x</div>
+    </div>
+
+    <h2>Element min/max widths</h2>
+    <p>.flexi--w&gt;4x = min-width: 4*96px; (think, greater than 4x)</p>
+    <p>.flexi--w&lt;4x = max-width: 4*96px; (think, less than 4x)</p>
+
+    <div class="flexb container">
+      <div class="box flexi--w>4x flexi--w<5x flexi--g1">&gt;4x &lt;5x</div>
+      <div class="box flexi--w<1x flexi--g1">&lt;1x</div>
+      <div class="box flexi--w>3x flexi--g1">&gt;3x</div>
     </div>
 
     <h2>Flex grow</h2>

--- a/muscles/item.flex.css
+++ b/muscles/item.flex.css
@@ -86,6 +86,29 @@
   }
 }
 
+/* width .flexi--wNx */
+@for $i from 1 to 12 {
+  .flexi--w$(i)x {
+    width: calc($muscles_base_basis * $i); 
+  }
+}
+
+/* max-width .flexi--w<Nx (width is less than Nx) */
+@for $i from 1 to 12 {
+  .flexi--w\<$(i)x {
+    max-width: calc($muscles_base_basis * $i); 
+  }
+}
+
+/* min-width .flexi--w>Nx (width is greater than Nx) */
+@for $i from 1 to 12 {
+  .flexi--w\>$(i)x {
+    min-width: calc($muscles_base_basis * $i); 
+  }
+}
+
+
+
 /**
  * order modifiers
  */


### PR DESCRIPTION
adds super experimental width modifiers (possibly a replacement for basis as basis:auto with a width basically does the same thing.
- `.flexi--wNx` for `width: N*96px;`
- `.flexi--w>Nx` for `min-width: N*96px;`
- `.flexi--w<Nx` for `max-width: N*96px;`
