### PR TITLE
add more style to examples

### DIFF
--- a/example/example.css
+++ b/example/example.css
@@ -1,0 +1,15 @@
+/* colorpallet http://paletton.com/#uid=33o0u0kllllaFw0g0qFqFg0w0aF */
+* {
+  box-sizing: border-box;
+}
+
+.flex {
+  background-color: #6B949F;
+}
+
+.flex > * {
+  background-color: #447684;
+  border: 1px solid #022A35;
+  color: #EEEEEE;
+
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,7 +9,11 @@ gulp.task('css', function() {
   var theme = {
     title: 'Muscles.css docs',
     examples: {
-      css: ['../dist/muscles.css']
+      css: [
+        '../dist/muscles.css', 
+        '../example/example.css', 
+        'http://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.2/normalize.min.css'
+      ]
     }
   };
   var processors = [

--- a/styleguide/index.html
+++ b/styleguide/index.html
@@ -2,7 +2,7 @@
 <title>Muscles.css docs</title>
 <meta charset="utf-8">
 <link href="style.css" rel="stylesheet">
-<script>examples={"base":"","target":"_self","css":["../dist/muscles.css"],"js":[],"bodyjs":[],"htmlcss":"background:none;border:0;clip:auto;display:block;height:auto;margin:0;padding:0;position:static;width:auto","bodycss":"background:none;border:0;clip:auto;display:block;height:auto;margin:0;padding:16px;position:static;width:auto"};</script>
+<script>examples={"base":"","target":"_self","css":["../dist/muscles.css","../example/example.css","http://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.2/normalize.min.css"],"js":[],"bodyjs":[],"htmlcss":"background:none;border:0;clip:auto;display:block;height:auto;margin:0;padding:0;position:static;width:auto","bodycss":"background:none;border:0;clip:auto;display:block;height:auto;margin:0;padding:16px;position:static;width:auto"};</script>
 <header>
 	<nav>
 		<img src="mdcss-logo.png" alt="Muscles.css docs">
@@ -677,7 +677,7 @@ than certain extremes.</p>
 			</div>
 		</section>
 		
-	<footer>Last modified Wednesday, 30 December 2015 14:18
+	<footer>Last modified Saturday, 2 January 2016 17:05
 </main>
 <script src="prism.js"></script>
 <script src="examples.js"></script>


### PR DESCRIPTION
examples were missing some styles to differentiate flex containers from items.

fixes #36 
