### PR TITLE
script the gh-pages deploy for portability

### DIFF
--- a/bin/gh-pages.sh
+++ b/bin/gh-pages.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# force push the gh-pages directory to the gh-pages branch
+
+# for CI, you will need to add the GIT_AUTHOR_NAME, GIT_AUTHOR_EMAIL
+# environment variables and set a SSH key
+
+cd gh-pages
+rm -rf .git
+git init
+
+git add .
+git commit -m "deploy new gh-pages"
+result="$(git push -f git@github.com:/jonotron/muscles.css.git master:gh-pages)"
+
+if [[ $? -ne 0 ]]
+then
+  echo "$result"
+  exit 1 
+else
+  echo "pushed to github pages"
+fi
+


### PR DESCRIPTION
this simplifies the deployment by bringing the script into the repository... it can be run from the developer's machine or via CI
